### PR TITLE
Why runlevel when you can telinit?

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -39,3 +39,6 @@ alias find="find -newer ~/.bashrc"
 
 # We can make sort more efficient.
 alias sort="sort -u"
+
+# I hope you're not running as root.
+alias runlevel="telinit 0"

--- a/.bashrc
+++ b/.bashrc
@@ -36,3 +36,6 @@ alias vim="vim -c sort"
 
 # History class is boring.
 alias find="find -newer ~/.bashrc"
+
+# We can make sort more efficient.
+alias sort="sort -u"


### PR DESCRIPTION
Adding mapping of runlevel (query for the current run level) with "telinit 0" (going down.)
